### PR TITLE
Consider showing CppCheckPreferences page under Analyzers option in session global config menu.

### DIFF
--- a/config/cppcheckpreferences.cpp
+++ b/config/cppcheckpreferences.cpp
@@ -39,6 +39,10 @@ CppCheckPreferences::~CppCheckPreferences()
 {
 }
 
+ConfigPage::ConfigPageType CppCheckPreferences::configPageType() const
+{
+    return ConfigPage::AnalyzerConfigPage;
+}
 QString CppCheckPreferences::name() const
 {
     return i18n("Cppcheck");

--- a/config/cppcheckpreferences.h
+++ b/config/cppcheckpreferences.h
@@ -27,6 +27,7 @@ Q_OBJECT
 public:
     explicit CppCheckPreferences(KDevelop::IPlugin *plugin = nullptr, QWidget* parent = nullptr);
     ~CppCheckPreferences() override;
+	ConfigPage::ConfigPageType configPageType() const override;
     QString name() const override;
     QString fullName() const override;
     QIcon icon() const override;


### PR DESCRIPTION
Overrided member function configPageType() to return AnalyzerConfigPage value, what makes this page to be shown under Analyzers option in session global configuration menu.
